### PR TITLE
Migrate to .NET 8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
 
       - name: "publish application"
         run: ${{github.workspace}}\publish.cmd ${{github.workspace}}

--- a/.github/workflows/testRunners.yml
+++ b/.github/workflows/testRunners.yml
@@ -44,6 +44,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '8.0.x'
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:

--- a/McServersScanner.Benchmark/McServersScanner.Benchmark.csproj
+++ b/McServersScanner.Benchmark/McServersScanner.Benchmark.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/McServersScanner.Benchmark/McServersScanner.Benchmark.csproj
+++ b/McServersScanner.Benchmark/McServersScanner.Benchmark.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.6" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/McServersScanner.Build/McServersScanner.Build.csproj
+++ b/McServersScanner.Build/McServersScanner.Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/McServersScanner.Build/McServersScanner.Build.csproj
+++ b/McServersScanner.Build/McServersScanner.Build.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="7.0.2" />
+    <PackageReference Include="Nuke.Common" Version="7.0.6" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.16.3" />
   </ItemGroup>
 

--- a/McServersScanner.Build/McServersScanner.Build.csproj
+++ b/McServersScanner.Build/McServersScanner.Build.csproj
@@ -8,6 +8,8 @@
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
+	<!--Temporal workaround for https://github.com/nuke-build/nuke/issues/818-->
+	<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/McServersScanner.Core/McServersScanner.Core.csproj
+++ b/McServersScanner.Core/McServersScanner.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/McServersScanner.Core/McServersScanner.Core.csproj
+++ b/McServersScanner.Core/McServersScanner.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageReference Include="Serilog" Version="3.0.1" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Realm" Version="11.5.0" />
+    <PackageReference Include="Realm" Version="11.6.1" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 

--- a/McServersScanner.Tests/McServersScanner.Tests.csproj
+++ b/McServersScanner.Tests/McServersScanner.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/McServersScanner.Tests/McServersScanner.Tests.csproj
+++ b/McServersScanner.Tests/McServersScanner.Tests.csproj
@@ -9,12 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/McServersScanner.Tests/Network/McClientTests.cs
+++ b/McServersScanner.Tests/Network/McClientTests.cs
@@ -29,7 +29,7 @@ namespace McServersScanner.Tests.Network
 
             if (!client.IsConnected)
             {
-                Assert.Warn("Client couldn't connect to {0}", targetIp);
+                Assert.Warn($"Client couldn't connect to {targetIp}");
                 return;
             }
 

--- a/McServersScanner/McServersScanner.csproj
+++ b/McServersScanner/McServersScanner.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/McServersScanner/McServersScanner.csproj
+++ b/McServersScanner/McServersScanner.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
-    <PackageReference Include="Realm" Version="11.5.0" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Realm" Version="11.6.1" />
     <PackageReference Include="Realm.Fody" Version="11.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Scan a range of ips for running minecraft servers
 
 Please make sure you have the following prerequisites:
 
-- A desktop platform with the [.NET 6.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed.
+- A desktop platform with the [.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) installed.
 
 ### Download the source code
 
@@ -32,7 +32,7 @@ If you are not interested in debugging McServerScanner, you can add `-c Release`
 To run McServerScanner go to the build directory and run the executable or run the following commands:
 
 ```shell
-cd McServersScanner\bin\Debug\net6.0 
+cd McServersScanner\bin\Debug\net8.0 
 McServersScanner --help
 ```
 


### PR DESCRIPTION
# Migrate to .NET 8 to improve performance.

## Improvements:
Performance gain in `ServerInfo` JSON deserialization
| Method                  | Mean     | Error    | StdDev  | Gen0   | Allocated |
|------------------------ |---------:|---------:|--------:|-------:|----------:|
| DeserializeToServerInfo (,NET 6)| 1.283 μs | 0.0207 μs | 0.0193 μs | 0.0572 |     960 B |
| DeserializeToServerInfo (.NET 8) | 856.1 ns | 10.25 ns | 9.08 ns | 0.0563 |     944 B |

Overall memory usage improvements (*~40% reduce of memory usage*).
